### PR TITLE
링크 맞춤법 수정 및 축약

### DIFF
--- a/layout.vue
+++ b/layout.vue
@@ -296,7 +296,7 @@
                                     <span :class="bulma('icon')">
                                         <buma-font-awesome-icon icon="fa-solid fas fa-chart-line"></buma-font-awesome-icon>
                                     </span>
-                                    <span class="wiki-article-menu-text"> 기여내역</span>
+                                    <span class="wiki-article-menu-text"> 기여 </span>
                                 </nuxt-link>
                             </li>
                         </ul>
@@ -307,7 +307,7 @@
                                     <span :class="bulma('icon')">
                                         <buma-font-awesome-icon icon="fa-solid fa-cogs"></buma-font-awesome-icon>
                                     </span>
-                                    <span class="wiki-article-menu-text"> 특수문서</span>
+                                    <span class="wiki-article-menu-text"> 특수 문서</span>
                                 </a>
                             </li>
                         </ul>

--- a/layout.vue
+++ b/layout.vue
@@ -296,7 +296,7 @@
                                     <span :class="bulma('icon')">
                                         <buma-font-awesome-icon icon="fa-solid fas fa-chart-line"></buma-font-awesome-icon>
                                     </span>
-                                    <span class="wiki-article-menu-text"> 기여 </span>
+                                    <span class="wiki-article-menu-text"> 기여 목록</span>
                                 </nuxt-link>
                             </li>
                         </ul>


### PR DESCRIPTION
fixes #68
추가로 리버티가 "기여 내역"이 "기여"로 고쳤으므로 여기 스킨에도 "기여"로 고쳤습니다.